### PR TITLE
Add Support for Key within number

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -75,8 +75,8 @@ describe('getHotFixLabel()', () => {
 describe('getJIRAIssueKeys()', () => {
   it('gets multiple keys from a string', () => {
     expect(
-      getJIRAIssueKeys('BF-18 abc-123 X-88 ABCDEFGHIJKL-999 abc XY-Z-333 abcDEF-33 ABCDEF-33 abcdef-33 ABC-1')
-    ).toEqual(['BF-18', 'ABC-123', 'X-88', 'CDEFGHIJKL-999', 'Z-333', 'ABCDEF-33', 'ABCDEF-33', 'ABCDEF-33', 'ABC-1']);
+      getJIRAIssueKeys('BF-18 abc-123 X-88 ABCDEFGHIJKL-999 abc XY-Z-333 abcDEF-33 ABCDEF-33 abcdef-33 ABC-1 PB2-1 pb2-1 P2P-1 p2p-1')
+    ).toEqual(['BF-18', 'ABC-123', 'X-88', 'CDEFGHIJKL-999', 'Z-333', 'ABCDEF-33', 'ABCDEF-33', 'ABCDEF-33', 'ABC-1', 'PB2-1', 'pb2-1', 'P2P-1', 'p2p-1']);
   });
 
   it('gets jira key from different branch names', () => {

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -76,7 +76,7 @@ describe('getJIRAIssueKeys()', () => {
   it('gets multiple keys from a string', () => {
     expect(
       getJIRAIssueKeys('BF-18 abc-123 X-88 ABCDEFGHIJKL-999 abc XY-Z-333 abcDEF-33 ABCDEF-33 abcdef-33 ABC-1 PB2-1 pb2-1 P2P-1 p2p-1')
-    ).toEqual(['BF-18', 'ABC-123', 'X-88', 'CDEFGHIJKL-999', 'Z-333', 'ABCDEF-33', 'ABCDEF-33', 'ABCDEF-33', 'ABC-1', 'PB2-1', 'pb2-1', 'P2P-1', 'p2p-1']);
+    ).toEqual(['BF-18', 'ABC-123', 'X-88', 'CDEFGHIJKL-999', 'Z-333', 'ABCDEF-33', 'ABCDEF-33', 'ABCDEF-33', 'ABC-1', 'PB2-1', 'PB2-1', 'P2P-1', 'P2P-1']);
   });
 
   it('gets jira key from different branch names', () => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,4 +11,4 @@ export const DEFAULT_BRANCH_PATTERNS:  RegExp[] = [
   /^gh-pages$/,
 ];
 
-export const JIRA_REGEX_MATCHER = /\d+-(([A-Z]{1,10})|[a-z]{1,10})/g;
+export const JIRA_REGEX_MATCHER = /\d+-(([A-Z0-9]{1,10})|[a-z0-9]{1,10})/g;


### PR DESCRIPTION
support JIRA project key like "PB2-1", "pb2-1", "P2P-1", "p2p-1".

my jira project key is "PB2", and jira-lint do not recognize it. 

![image](https://user-images.githubusercontent.com/60565646/78964300-4be07480-7b2c-11ea-99af-c4a728ed0298.png)
