### PR TITLE
DBA-833: Clone jira-lint and update to node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ inputs:
     required: false
     default: 800
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'lib/index.js'
 branding:
   icon: 'check-square'


### PR DESCRIPTION
Point to node 16 as node 12 is deprecated